### PR TITLE
[IMP] sale_discount_display_amount: improve layout sale discount total

### DIFF
--- a/sale_discount_display_amount/views/sale_view.xml
+++ b/sale_discount_display_amount/views/sale_view.xml
@@ -19,37 +19,35 @@
         <field name="priority">99</field>
         <field name="arch" type="xml">
             <data>
-                <xpath expr="//field[@name='tax_totals']" position="after">
-                    <field
-                        name="display_discount_with_tax"
-                        invisible="1"
-                        position="attributes"
+                <xpath expr="//group[@name='sale_total']" position="after">
+                    <group
+                        class="oe_subtotal_footer"
+                        colspan="2"
+                        name="sale_discount_total"
                     >
-                    </field>
-                    <field
-                        name="price_subtotal_no_discount"
-                        invisible="display_discount_with_tax == True"
-                        position="attributes"
-                    >
-                    </field>
-                    <field
-                        name="discount_subtotal"
-                        invisible="display_discount_with_tax == True"
-                        position="attributes"
-                    >
-                    </field>
-                    <field
-                        name="price_total_no_discount"
-                        invisible="display_discount_with_tax == False"
-                        position="attributes"
-                    >
-                    </field>
-                    <field
-                        name="discount_total"
-                        invisible="display_discount_with_tax == False"
-                        position="attributes"
-                    >
-                    </field>
+                        <field name="display_discount_with_tax" invisible="1">
+                        </field>
+                        <field
+                            name="price_subtotal_no_discount"
+                            invisible="display_discount_with_tax"
+                        >
+                        </field>
+                        <field
+                            name="discount_subtotal"
+                            invisible="display_discount_with_tax"
+                        >
+                        </field>
+                        <field
+                            name="price_total_no_discount"
+                            invisible="not display_discount_with_tax"
+                        >
+                        </field>
+                        <field
+                            name="discount_total"
+                            invisible="not display_discount_with_tax"
+                        >
+                        </field>
+                    </group>
                 </xpath>
             </data>
         </field>


### PR DESCRIPTION
There are some interface changes on the Sales Order form view that cause the total summary to be a bit broken.

before:
![image](https://github.com/user-attachments/assets/62c011ce-e9ce-4322-bc3b-4e66712e9dd3)

after:
![image](https://github.com/user-attachments/assets/8cdb3086-3018-431f-a304-e1e22d3f182e)
